### PR TITLE
Use GET for delegation-status endpoint

### DIFF
--- a/src/gcore/resources/dns/zones/zones.py
+++ b/src/gcore/resources/dns/zones/zones.py
@@ -317,7 +317,7 @@ class ZonesResource(SyncAPIResource):
         """
         if not name:
             raise ValueError(f"Expected a non-empty value for `name` but received {name!r}")
-        return self._post(
+        return self._get(
             f"/dns/v2/analyze/{name}/delegation-status",
             options=make_request_options(
                 extra_headers=extra_headers, extra_query=extra_query, extra_body=extra_body, timeout=timeout


### PR DESCRIPTION
It looks like this endpoint responds to GET and not POST. https://gcore.com/docs/api-reference/dns/analyze/check-delegation-status must be updated accordingly.